### PR TITLE
Make plugin compatible with postgresql

### DIFF
--- a/lib/last_updated_by_issue_patch.rb
+++ b/lib/last_updated_by_issue_patch.rb
@@ -23,7 +23,7 @@ module LastUpdatedByIssuePatch
       else #postgre and mysql
         sqlStr = "select CONCAT_WS(' ', u.firstname, u.lastname) as name"
       end
-			_sql = sqlStr + ", u.id as id from #{Journal.table_name} as j1 inner join #{User.table_name} as u on u.id = j1.`user_id` where `journalized_type` = 'Issue' and `journalized_id` = #{id} order by j1.`id` DESC limit 1"
+			_sql = sqlStr + ", u.id as id from #{Journal.table_name} as j1 inner join #{User.table_name} as u on u.id = j1.user_id where journalized_type  = 'Issue' and journalized_id = #{id} order by j1.id DESC limit 1"
 			result = ActiveRecord::Base.connection.select_one _sql
 			updated_by_name = ""
 			updated_by_id = nil


### PR DESCRIPTION
lib/last_updated_by_issue_patch.rb uses backquotes around some of the database column names in the sql query it builds. This is illegal in postgresql and causes errors such as:

```
ActionView::Template::Error (PG::Error: ERROR:  syntax error at or near "`"
LINE 1: ...journals as j1 inner join users as u on u.id = j1.`user_id` ...
                                                         ^
: select CONCAT_WS(' ', u.firstname, u.lastname) as name, u.id as id from journals as j1 inner join users as u on u.id = j1.`user_id` where `journalized_type` = 'Issue' and `journalized_id` = 4354 order by j1.`id` DESC limit 1):
```

This patch removes these backquotes, which should be compatible with mysql and sqlite as well.
